### PR TITLE
Support variable

### DIFF
--- a/livestream/2019-04-12/client/client.go
+++ b/livestream/2019-04-12/client/client.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+// channel == synchronization queue == 同步队列？
+// -> 【】 ->
+
+func main() {
+	ch := make(chan task) //  connection pool , task pool
+	go receiver(ch)
+
+	buf := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Print("> ")
+		sentence, err := buf.ReadBytes('\n')
+		if err != nil {
+			panic(err)
+		}
+
+		if len(sentence) > 2 {
+			r := bytes.NewReader(
+				sentence[:len(sentence)-2])
+			go concurrent(r, ch)
+		}
+	}
+}
+
+func receiver(ch chan task) {
+	var tasks []task
+
+	started := make(chan struct{})
+
+	go func(ch chan task) {
+		t := <-ch
+		tasks = append(tasks, t)
+	}(ch)
+
+	i := 0
+	for {
+		<-started
+		body := <-tasks[i].body
+		i++
+		io.Copy(os.Stdout, body)
+		fmt.Println("??")
+	}
+}
+
+type task struct {
+	body chan io.Reader
+}
+
+func concurrent(r io.Reader, taskCh chan task) {
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost:8080", r)
+
+	// task channel 创建任务的时候，就放入channel
+	t := task{
+		body: make(chan io.Reader),
+	}
+	taskCh <- t
+	res, err := http.DefaultClient.Do(req) // 一个 Do 就是一个任务
+	if err != nil {
+		panic(err)
+	}
+	t.body <- res.Body // 结束的时候，通知该任务我结束了
+	// close(t.body)
+}

--- a/livestream/2019-04-12/server/server.go
+++ b/livestream/2019-04-12/server/server.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(time.Second * time.Duration(2+rand.Int()%3))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("慢慢慢！"))
+
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+
+		err = r.Body.Close()
+		if err != nil {
+			panic(err)
+		}
+
+		w.Write(b)
+	})
+	http.Handle("/", r)
+
+	log.Fatal(http.ListenAndServe("localhost:8080", r))
+}

--- a/projects/galculator/cmd/run.go
+++ b/projects/galculator/cmd/run.go
@@ -37,7 +37,7 @@ to quickly create a Cobra application.`,
 		if len(args) == 0 {
 			return errors.New("run command must have a math expression as the argument")
 		}
-		_, err := fmt.Println(compute.Compute(args[0]))
+		_, err := fmt.Println(compute.Compute(args[0], make(map[string]int64)))
 		return err
 	},
 }

--- a/projects/galculator/go.mod
+++ b/projects/galculator/go.mod
@@ -1,6 +1,7 @@
 module galculator
 
 require (
+	github.com/gorilla/mux v1.7.1
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v0.0.3

--- a/projects/galculator/go.sum
+++ b/projects/galculator/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gorilla/mux v1.7.1 h1:Dw4jY2nghMMRsh1ol8dv1axHkDwMQK2DHerMNJsIpJU=
+github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/projects/galculator/internel/compute/compute.go
+++ b/projects/galculator/internel/compute/compute.go
@@ -83,6 +83,9 @@ func parse(tokens []lexer.Token) (operatorStack []operator, operantStack []expre
 			}
 			operantStack = append(operantStack, pe)
 			inc = read + 1 // todo: coordinate the current read position of tokens...
+		case lexer.Identifier:
+			// todo:
+			fmt.Println("Warning:", t.Type(), t.Literal(), "is ignored")
 		default:
 			fmt.Println("Warning:", t.Type(), t.Literal(), "is ignored")
 		}
@@ -134,3 +137,22 @@ type ParenthesesExpression struct {
 func (pe ParenthesesExpression) Value() int64 {
 	return interpreting(pe.OperatorStack, pe.OperantStack)
 }
+
+// a = 1
+// Name == 'a'
+// Value == NumberExpression{1}
+//
+// a = (1+1)
+// Name == 'a'
+// Value == ParenthesesExpression{'(1+1)'}
+//
+// a = b = 1
+// a = (b = 1)
+// type AssignmentExpression struct {
+// 	Name  string
+// 	Value expression
+// }
+
+// func (ae AssignmentExpression) Value() int64 {
+// 	return ae.Value.Value()
+// }

--- a/projects/galculator/internel/compute/compute.go
+++ b/projects/galculator/internel/compute/compute.go
@@ -1,30 +1,78 @@
 package compute
 
 import (
-	"fmt"
+	"errors"
 	"galculator/internel/lexer"
 	"strconv"
 )
 
-type operator func(left expression, right expression) NumberExpression
+type variableMap map[string]int64
 
-func add(left, right expression) NumberExpression {
-	return NumberExpression{number: left.Value() + right.Value()}
+// todo: refactor operator to operator expression
+type operator func(left expression, right expression) (NumberExpression, error)
+
+func add(left, right expression) (ne NumberExpression, err error) {
+	lv, err2 := left.Value()
+	if err2 != nil {
+		err = err2
+		return
+	}
+	rv, err2 := right.Value()
+	if err2 != nil {
+		err = err2
+		return
+	}
+	return NumberExpression{lv + rv}, nil
 }
 
-func sub(left, right expression) NumberExpression {
-	return NumberExpression{number: left.Value() - right.Value()}
+func sub(left, right expression) (ne NumberExpression, err error) {
+	lv, err2 := left.Value()
+	if err2 != nil {
+		err = err2
+		return
+	}
+	rv, err2 := right.Value()
+	if err2 != nil {
+		err = err2
+		return
+	}
+	return NumberExpression{lv - rv}, nil
 }
 
-func mul(left, right expression) NumberExpression {
-	return NumberExpression{number: left.Value() * right.Value()}
+func mul(left, right expression) (ne NumberExpression, err error) {
+	lv, err2 := left.Value()
+	if err2 != nil {
+		err = err2
+		return
+	}
+	rv, err2 := right.Value()
+	if err2 != nil {
+		err = err2
+		return
+	}
+	return NumberExpression{lv * rv}, nil
 }
 
-func div(left, right expression) NumberExpression {
-	return NumberExpression{number: left.Value() / right.Value()}
+func div(left, right expression) (ne NumberExpression, err error) {
+	lv, err2 := left.Value()
+	if err2 != nil {
+		err = err2
+		return
+	}
+	rv, err2 := right.Value()
+	if err2 != nil {
+		err = err2
+		return
+	}
+	if rv == 0 {
+		err = errors.New("Divide by zero!") // todo: refactor to a MathError type
+		return
+	}
+	return NumberExpression{lv / rv}, nil
 }
 
-func Compute(input string) string {
+// Compute is the top level function of the interpreter.
+func Compute(input string, vm variableMap) string {
 	// Tokenization
 	tokens, err := lexer.Lex(input)
 	if err != nil {
@@ -32,127 +80,43 @@ func Compute(input string) string {
 	}
 
 	// Parsing
-	operatorStack, operantStack, err2 := parse(tokens)
+	operatorStack, operantStack, err2 := parse(&tokenSliceEmitter{tokens: tokens}, vm)
 	if err2 != nil {
 		return err2.Error()
 	}
 
-	return strconv.FormatInt(interpreting(operatorStack, operantStack), 10)
+	result, err3 := interpreting(operatorStack, operantStack)
+	if err3 != nil {
+		return err3.Error()
+	}
+	return strconv.FormatInt(result, 10)
 }
 
-func interpreting(operatorStack []operator, operantStack []expression) int64 {
+type tokenSliceEmitter struct {
+	tokens []lexer.Token
+	i      int
+}
+
+func (emitter *tokenSliceEmitter) Next() lexer.Token {
+	if emitter.i < len(emitter.tokens) {
+		defer func() { emitter.i++ }()
+		return emitter.tokens[emitter.i]
+	}
+	return nil
+}
+
+func interpreting(operatorStack []operator, operantStack []expression) (int64, error) {
 	var operatorFunc operator
 	var left, right expression
 	for len(operatorStack) > 0 {
 		operatorFunc, operatorStack = operatorStack[0], operatorStack[1:]
 		left, operantStack = operantStack[0], operantStack[1:]
 		right, operantStack = operantStack[0], operantStack[1:]
-		operantStack = append([]expression{operatorFunc(left, right)}, operantStack...)
+		result, err := operatorFunc(left, right)
+		if err != nil {
+			return 0, err
+		}
+		operantStack = append([]expression{result}, operantStack...)
 	}
 	return operantStack[0].Value()
 }
-
-func parse(tokens []lexer.Token) (operatorStack []operator, operantStack []expression, err error) {
-	operators := map[lexer.Operator]operator{
-		lexer.Add: add,
-		lexer.Sub: sub,
-		lexer.Mul: mul,
-		lexer.Div: div,
-	}
-
-	for i := 0; i < len(tokens); {
-		inc := 1
-		switch t := tokens[i].(type) {
-		case lexer.Operator:
-			if operator, ok := operators[t]; ok {
-				operatorStack = append(operatorStack, operator)
-			} else {
-				panic("?")
-			}
-		case lexer.Number:
-			integer, err := strconv.ParseInt(t.Value, 10, 64)
-			if err != nil {
-				panic(err)
-			}
-			operantStack = append(operantStack, NumberExpression{number: integer})
-		case lexer.LeftParentheses:
-			pe, read, err2 := ParseParenthesisExpression(tokens[i+1:])
-			if err2 != nil {
-				err = err2
-				return
-			}
-			operantStack = append(operantStack, pe)
-			inc = read + 1 // todo: coordinate the current read position of tokens...
-		case lexer.Identifier:
-			// todo:
-			fmt.Println("Warning:", t.Type(), t.Literal(), "is ignored")
-		default:
-			fmt.Println("Warning:", t.Type(), t.Literal(), "is ignored")
-		}
-		i += inc
-	}
-	return
-}
-
-// ParseParenthesisExpression parse a sequence of tokens and return the first full parenthesis expression.
-// ( 1 + 1 ) + 1 ) will return expression"((1+1)+1)"
-// This function always inserts a leading ( at the beginning of the tokens.
-func ParseParenthesisExpression(s []lexer.Token) (ParenthesesExpression, int, error) {
-	count := 1
-	for i, token := range s {
-		switch token.(type) {
-		case lexer.LeftParentheses:
-			count++
-		case lexer.RightParentheses:
-			count--
-		}
-		if count == 0 {
-			operatorStack, operantStack, err := parse(s[:i])
-			return ParenthesesExpression{
-				OperatorStack: operatorStack,
-				OperantStack:  operantStack,
-			}, i + 1, err
-		}
-	}
-	return ParenthesesExpression{}, len(s), &ParsingError{fmt.Sprintf("Missing %d ) parentheses", count)}
-}
-
-type expression interface {
-	Value() int64
-}
-
-type NumberExpression struct {
-	number int64
-}
-
-func (ne NumberExpression) Value() int64 {
-	return ne.number
-}
-
-type ParenthesesExpression struct {
-	OperatorStack []operator
-	OperantStack  []expression
-}
-
-func (pe ParenthesesExpression) Value() int64 {
-	return interpreting(pe.OperatorStack, pe.OperantStack)
-}
-
-// a = 1
-// Name == 'a'
-// Value == NumberExpression{1}
-//
-// a = (1+1)
-// Name == 'a'
-// Value == ParenthesesExpression{'(1+1)'}
-//
-// a = b = 1
-// a = (b = 1)
-// type AssignmentExpression struct {
-// 	Name  string
-// 	Value expression
-// }
-
-// func (ae AssignmentExpression) Value() int64 {
-// 	return ae.Value.Value()
-// }

--- a/projects/galculator/internel/compute/compute_test.go
+++ b/projects/galculator/internel/compute/compute_test.go
@@ -12,6 +12,10 @@ func TestCompute(t *testing.T) {
 	require.Equal(t, "2", Compute("1+1"))
 	require.Equal(t, "2", Compute("(1+1)"))
 	require.Equal(t, "233", Compute("233)))"))
+	require.Equal(t, "a = 1", Compute("a = 1"))       // ?
+	require.Equal(t, "a = 4", Compute("a = (1 + 3)")) // ?
+	require.Equal(t, "a = 4", Compute("a = 1 + 3"))   // ?
+	require.Equal(t, "0", Compute("(a = 1 + 3) - 4")) // ?
 }
 
 func TestComputeError(t *testing.T) {

--- a/projects/galculator/internel/compute/compute_test.go
+++ b/projects/galculator/internel/compute/compute_test.go
@@ -12,10 +12,10 @@ func TestCompute(t *testing.T) {
 	require.Equal(t, "2", Compute("1+1"))
 	require.Equal(t, "2", Compute("(1+1)"))
 	require.Equal(t, "233", Compute("233)))"))
-	require.Equal(t, "a = 1", Compute("a = 1"))       // ?
-	require.Equal(t, "a = 4", Compute("a = (1 + 3)")) // ?
-	require.Equal(t, "a = 4", Compute("a = 1 + 3"))   // ?
-	require.Equal(t, "0", Compute("(a = 1 + 3) - 4")) // ?
+	require.Equal(t, "1", Compute("a = 1"))            // ?
+	require.Equal(t, "4", Compute("a = (1 + 3)"))      // ?
+	require.Equal(t, "4", Compute("a = 1 + 3"))        // ?
+	require.Equal(t, "-2", Compute("(a = 1) - 4 + a")) // ?
 }
 
 func TestComputeError(t *testing.T) {

--- a/projects/galculator/internel/compute/expression.go
+++ b/projects/galculator/internel/compute/expression.go
@@ -1,0 +1,93 @@
+package compute
+
+import (
+	"errors"
+	"fmt"
+	"galculator/internel/lexer"
+)
+
+type expression interface {
+	Value() (int64, error)
+}
+
+// NumberExpression represents an integer value
+type NumberExpression struct {
+	number int64
+}
+
+func (ne NumberExpression) Value() (int64, error) {
+	return ne.number, nil
+}
+
+type OperatorExpression struct {
+	Op    lexer.Operator
+	Left  expression
+	Right expression
+}
+
+func (oe OperatorExpression) Value() (int64, error) {
+	lv, err2 := oe.Left.Value()
+	if err2 != nil {
+		return 0, err2
+	}
+	rv, err2 := oe.Right.Value()
+	if err2 != nil {
+		return 0, err2
+	}
+	switch oe.Op {
+	case lexer.Add:
+		return lv + rv, nil
+	case lexer.Sub:
+		return lv - rv, nil
+	case lexer.Mul:
+		return lv * rv, nil
+	case lexer.Div:
+		if rv == 0 {
+			return 0, errors.New("Divide by zero!") // todo: refactor to a MathError type
+		}
+		return lv / rv, nil
+	default:
+		return 0, errors.New("Op not recognized")
+	}
+}
+
+// ParenthesesExpression is
+// ( expression )
+type ParenthesesExpression struct {
+	OperatorStack []operator
+	OperantStack  []expression
+}
+
+func (pe ParenthesesExpression) Value() (int64, error) {
+	return interpreting(pe.OperatorStack, pe.OperantStack)
+}
+
+// AssignmentExpression is
+// identifier = expression
+type AssignmentExpression struct {
+	Name       string
+	expression expression
+	vm         variableMap
+}
+
+func (ae AssignmentExpression) Value() (int64, error) {
+	v, err := ae.expression.Value()
+	if err != nil {
+		return 0, nil
+	}
+	ae.vm[ae.Name] = v
+	return v, nil
+}
+
+// IdentifierExpression is an identifier by itself.
+type IdentifierExpression struct {
+	Name     string
+	ValueMap map[string]int64
+}
+
+func (ie IdentifierExpression) Value() (int64, error) {
+	if v, ok := ie.ValueMap[ie.Name]; ok {
+		return v, nil
+	}
+	return 0, fmt.Errorf("Variable %s is not defined", ie.Name)
+}

--- a/projects/galculator/internel/compute/parse.go
+++ b/projects/galculator/internel/compute/parse.go
@@ -90,7 +90,7 @@ func ParseParenthesisExpression(tokens tokenEmitter, vm variableMap) (Parenthese
 // identifier EOF
 func parseIdentifierExpression(tokens tokenEmitter, identifier lexer.Identifier, vm map[string]int64) (expression, error) {
 	next := tokens.Next()
-	switch next.(type) {
+	switch token := next.(type) {
 	case lexer.EqualSign:
 		// return an assignment expression
 		exp, err := parseExpression(tokens, vm)
@@ -103,7 +103,15 @@ func parseIdentifierExpression(tokens tokenEmitter, identifier lexer.Identifier,
 			vm:         vm,
 		}, nil
 	case lexer.Operator:
-		// return normal 'exp op exp' pair
+		exp, err := parseExpression(tokens, vm)
+		if err != nil {
+			return nil, err
+		}
+		return OperatorExpression{
+			Op:    token,
+			Left:  IdentifierExpression{Name: identifier.Literal(), ValueMap: vm},
+			Right: exp,
+		}, nil
 	case nil: // EOF
 		// return the identifier itself
 		return IdentifierExpression{Name: identifier.Literal(), ValueMap: vm}, nil

--- a/projects/galculator/internel/compute/parse.go
+++ b/projects/galculator/internel/compute/parse.go
@@ -1,0 +1,154 @@
+package compute
+
+import (
+	"errors"
+	"fmt"
+	"galculator/internel/lexer"
+	"strconv"
+)
+
+// This interface happens to match https://golang.org/pkg/text/scanner/#Scanner.Next
+type tokenEmitter interface {
+	Next() lexer.Token
+}
+
+func parse(tokens tokenEmitter, vm variableMap) (operatorStack []operator, operantStack []expression, err error) {
+	operators := map[lexer.Operator]operator{
+		lexer.Add: add,
+		lexer.Sub: sub,
+		lexer.Mul: mul,
+		lexer.Div: div,
+	}
+
+	for next := tokens.Next(); next != nil; next = tokens.Next() {
+		switch t := next.(type) {
+		case nil:
+			return
+		case lexer.Operator:
+			if operator, ok := operators[t]; ok {
+				operatorStack = append(operatorStack, operator)
+			} else {
+				panic("?")
+			}
+		case lexer.Number:
+			integer, err := strconv.ParseInt(t.Value, 10, 64)
+			if err != nil {
+				panic(err)
+			}
+			operantStack = append(operantStack, NumberExpression{number: integer})
+		case lexer.LeftParentheses:
+			pe, err2 := ParseParenthesisExpression(tokens, vm)
+			if err2 != nil {
+				err = err2
+				return
+			}
+			operantStack = append(operantStack, pe)
+		case lexer.Identifier:
+			exp, err2 := parseIdentifierExpression(tokens, t, vm) // todo: initt variable map elsewhere
+			if err2 != nil {
+				err = err2
+				return
+			}
+			operantStack = append(operantStack, exp)
+		default:
+			fmt.Println("Warning:", t.Type(), t.Literal(), "is ignored")
+		}
+	}
+	return
+}
+
+// ParseParenthesisExpression parse a sequence of tokens and return the first full parenthesis expression.
+// ( 1 + 1 ) + 1 ) will return expression"((1+1)+1)"
+// This function always inserts a leading ( at the beginning of the tokens.
+func ParseParenthesisExpression(tokens tokenEmitter, vm variableMap) (ParenthesesExpression, error) {
+	count := 1
+	var readTokens []lexer.Token
+	for next := tokens.Next(); next != nil; next = tokens.Next() {
+		readTokens = append(readTokens, next)
+		switch next.(type) {
+		case nil:
+			return ParenthesesExpression{}, &ParsingError{fmt.Sprintf("Missing %d ) parentheses", count)}
+		case lexer.LeftParentheses:
+			count++
+		case lexer.RightParentheses:
+			count--
+		}
+		if count == 0 {
+			operatorStack, operantStack, err := parse(&tokenSliceEmitter{tokens: readTokens[:len(readTokens)-1]}, vm)
+			return ParenthesesExpression{
+				OperatorStack: operatorStack,
+				OperantStack:  operantStack,
+			}, err
+		}
+	}
+	return ParenthesesExpression{}, &ParsingError{fmt.Sprintf("Missing %d ) parentheses", count)}
+}
+
+// This is the context free grammar for identifier
+// identifier = expression
+// identifier operator expression
+// identifier EOF
+func parseIdentifierExpression(tokens tokenEmitter, identifier lexer.Identifier, vm map[string]int64) (expression, error) {
+	next := tokens.Next()
+	switch next.(type) {
+	case lexer.EqualSign:
+		// return an assignment expression
+		exp, err := parseExpression(tokens, vm)
+		if err != nil {
+			return nil, err
+		}
+		return AssignmentExpression{
+			Name:       identifier.Literal(),
+			expression: exp,
+			vm:         vm,
+		}, nil
+	case lexer.Operator:
+		// return normal 'exp op exp' pair
+	case nil: // EOF
+		// return the identifier itself
+		return IdentifierExpression{Name: identifier.Literal(), ValueMap: vm}, nil
+	default:
+		return nil, &ParsingError{fmt.Sprintf("An identifier must be followed by 1 of the 4: = expression, operator expression, ), EOF. But got %T:%v", next, next)}
+	}
+	return nil, &ParsingError{"3 todo: should not reach"}
+}
+
+// This function returns the first expression parsed immediated or an error.
+// expression |
+// number
+// parentheses-expression
+// identifier-expression
+// assignment-expression
+func parseExpression(tokens tokenEmitter, vm variableMap) (expression, error) {
+	next := tokens.Next()
+	switch token := next.(type) {
+	case lexer.Number:
+		integer, err := strconv.ParseInt(token.Value, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		np := NumberExpression{number: integer}
+
+		next = tokens.Next()
+		if next == nil {
+			return np, nil
+		}
+
+		if op, ok := next.(lexer.Operator); ok {
+			exp, err := parseExpression(tokens, vm)
+			if err != nil {
+				return nil, err
+			}
+			return OperatorExpression{Op: op, Left: np, Right: exp}, nil
+		}
+
+		return nil, errors.New("2 todo: should not reach???")
+
+	case lexer.LeftParentheses:
+		return ParseParenthesisExpression(tokens, vm)
+
+	case lexer.Identifier:
+		return parseIdentifierExpression(tokens, token, vm)
+	}
+	return NumberExpression{number: 1}, errors.New("1 todo: should not reach")
+}

--- a/projects/galculator/internel/compute/parse_test.go
+++ b/projects/galculator/internel/compute/parse_test.go
@@ -1,0 +1,175 @@
+package compute
+
+import (
+	"galculator/internel/lexer"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsingIdentifierExpression(t *testing.T) {
+	tokens, _ := lexer.Lex("a = 233")
+	exp, err := parseIdentifierExpression(&tokenSliceEmitter{tokens: tokens[1:]}, lexer.Identifier{Value: "a"}, nil)
+	require.NoError(t, err)
+	if ae, ok := exp.(AssignmentExpression); ok {
+		require.Equal(t, "a", ae.Name)
+		value, err := ae.Value()
+		require.Equal(t, int64(233), value)
+		require.NoError(t, err)
+	} else {
+		a := require.New(t)
+		a.FailNowf("not an assignment expression", "got %T", exp)
+	}
+
+	tokens, _ = lexer.Lex("a = 233 + 1")
+	exp, err = parseIdentifierExpression(&tokenSliceEmitter{tokens: tokens[1:]}, lexer.Identifier{Value: "a"}, nil)
+	require.NoError(t, err)
+	if ae, ok := exp.(AssignmentExpression); ok {
+		require.Equal(t, "a", ae.Name)
+		value, err := ae.Value()
+		require.Equal(t, int64(234), value)
+		require.NoError(t, err)
+	} else {
+		a := require.New(t)
+		a.FailNowf("not an assignment expression", "got %T", exp)
+	}
+
+	tokens, _ = lexer.Lex("a = 1 + 2 + 3")
+	exp, err = parseIdentifierExpression(&tokenSliceEmitter{tokens: tokens[1:]}, lexer.Identifier{Value: "a"}, nil)
+	require.NoError(t, err)
+	if ae, ok := exp.(AssignmentExpression); ok {
+		require.Equal(t, "a", ae.Name)
+		value, err := ae.Value()
+		require.Equal(t, int64(6), value)
+		require.NoError(t, err)
+	} else {
+		a := require.New(t)
+		a.FailNowf("not an assignment expression", "got %T", exp)
+	}
+
+	tokens, _ = lexer.Lex("a = 1 + (2 + 3)")
+	exp, err = parseIdentifierExpression(&tokenSliceEmitter{tokens: tokens[1:]}, lexer.Identifier{Value: "a"}, nil)
+	require.NoError(t, err)
+	if ae, ok := exp.(AssignmentExpression); ok {
+		require.Equal(t, "a", ae.Name)
+		value, err := ae.Value()
+		require.Equal(t, int64(6), value)
+		require.NoError(t, err)
+	} else {
+		a := require.New(t)
+		a.FailNowf("not an assignment expression", "got %T", exp)
+	}
+
+	tokens, _ = lexer.Lex("a = (1 + 2 + a) + 3")
+	exp, err = parseIdentifierExpression(&tokenSliceEmitter{tokens: tokens[1:]}, lexer.Identifier{Value: "a"}, nil)
+	require.NoError(t, err)
+	if ae, ok := exp.(AssignmentExpression); ok {
+		require.Equal(t, "a", ae.Name)
+		value, err := ae.Value()
+		require.EqualError(t, err, "Variable a is not defined")
+		require.Equal(t, int64(0), value)
+	} else {
+		a := require.New(t)
+		a.FailNowf("not an assignment expression", "got %T", exp)
+	}
+}
+
+func TestParsingExpression(t *testing.T) {
+	t.Run("parse identifier exp", func(t2 *testing.T) {
+		tokens, _ := lexer.Lex("(a)")
+		exp, err := parseExpression(&tokenSliceEmitter{tokens: tokens}, nil)
+		require.NoError(t, err)
+		require.IsType(t, ParenthesesExpression{}, exp)
+		result, err := exp.Value()
+		require.EqualError(t, err, "Variable a is not defined")
+		require.Equal(t, int64(0), result)
+	})
+
+	t.Run("parse +-*/ exp", func(t2 *testing.T) {
+		tokens, _ := lexer.Lex("1+1")
+		exp, err := parseExpression(&tokenSliceEmitter{tokens: tokens}, nil)
+		require.NoError(t, err)
+		require.IsType(t, OperatorExpression{}, exp)
+		result, err := exp.Value()
+		require.NoError(t, err)
+		require.Equal(t, int64(2), result)
+
+		tokens, _ = lexer.Lex("1-2")
+		exp, err = parseExpression(&tokenSliceEmitter{tokens: tokens}, nil)
+		require.NoError(t, err)
+		require.IsType(t, OperatorExpression{}, exp)
+		result, err = exp.Value()
+		require.NoError(t, err)
+		require.Equal(t, int64(-1), result)
+
+		tokens, _ = lexer.Lex("666*998")
+		exp, err = parseExpression(&tokenSliceEmitter{tokens: tokens}, nil)
+		require.NoError(t, err)
+		require.IsType(t, OperatorExpression{}, exp)
+		result, err = exp.Value()
+		require.NoError(t, err)
+		require.Equal(t, int64(666*998), result)
+
+		tokens, _ = lexer.Lex("6/2")
+		exp, err = parseExpression(&tokenSliceEmitter{tokens: tokens}, nil)
+		require.NoError(t, err)
+		require.IsType(t, OperatorExpression{}, exp)
+		result, err = exp.Value()
+		require.NoError(t, err)
+		require.Equal(t, int64(3), result)
+
+		tokens, _ = lexer.Lex("6/0")
+		exp, err = parseExpression(&tokenSliceEmitter{tokens: tokens}, nil)
+		require.NoError(t, err)
+		require.IsType(t, OperatorExpression{}, exp)
+		result, err = exp.Value()
+		require.EqualError(t, err, "Divide by zero!")
+		require.Equal(t, int64(0), result)
+	})
+
+	t.Run("parse number exp", func(t2 *testing.T) {
+		tokens, _ := lexer.Lex("233")
+		exp, err := parseExpression(&tokenSliceEmitter{tokens: tokens}, nil)
+		require.NoError(t, err)
+		require.IsType(t, NumberExpression{}, exp)
+
+		result, err := exp.Value()
+		require.NoError(t, err)
+		require.Equal(t, int64(233), result)
+	})
+
+	t.Run("parse () exp", func(t2 *testing.T) {
+		tokens, _ := lexer.Lex("(233)")
+
+		exp, err := parseExpression(&tokenSliceEmitter{tokens: tokens}, nil)
+		require.NoError(t, err)
+		require.IsType(t, ParenthesesExpression{}, exp)
+
+		result, err := exp.Value()
+		require.NoError(t, err)
+		require.Equal(t, int64(233), result)
+
+		tokens, _ = lexer.Lex("(((100))+233+(1-100))")
+
+		exp, err = parseExpression(&tokenSliceEmitter{tokens: tokens}, nil)
+		require.NoError(t, err)
+		require.IsType(t, ParenthesesExpression{}, exp)
+
+		result, err = exp.Value()
+		require.NoError(t, err)
+		require.Equal(t, int64(234), result)
+	})
+
+	t.Run("parse = exp", func(t2 *testing.T) {
+		tokens, _ := lexer.Lex("a = 1 + 2 + 3")
+
+		exp, err := parseExpression(&tokenSliceEmitter{tokens: tokens}, nil)
+		require.NoError(t, err)
+		require.IsType(t, AssignmentExpression{}, exp)
+
+		result, err := exp.Value()
+		require.NoError(t, err)
+		require.Equal(t, int64(6), result)
+	})
+
+}

--- a/projects/galculator/internel/lexer/lexer_test.go
+++ b/projects/galculator/internel/lexer/lexer_test.go
@@ -113,14 +113,9 @@ func TestLexerParenthese(t *testing.T) {
 }
 
 func TestLexerError(t *testing.T) {
-	tokens, err := Lex("a")
-	require.Empty(t, tokens)
-	require.EqualError(t, err, "Lexing Error: character 'a' is not expected")
-
-	_, err = Lex("1 +a")
-	require.EqualError(t, err, "Lexing Error: character 'a' is not expected after an operator")
-	_, err = Lex("1 + function")
+	_, err := Lex("1 + function")
 	require.EqualError(t, err, "Lexing Error: character 'f' is not expected after an operator")
+
 	_, err = Lex("1 + +")
 	require.EqualError(t, err, "Lexing Error: character '+' is not expected after an operator")
 
@@ -138,4 +133,65 @@ func TestLexerError(t *testing.T) {
 
 	_, err = Lex("(()")
 	require.EqualError(t, err, "Lexing Error: An expression must be in between ( and )")
+}
+
+func TestAssignment(t *testing.T) {
+	tokens, err := Lex("babcccccc = 2")
+	require.Nil(t, err)
+	require.Equal(t,
+		[]Token{
+			Identifier{Value: "babcccccc"},
+			EqualSign{},
+			Number{Value: "2"},
+		},
+		tokens)
+
+	tokens, err = Lex("1 +a")
+	require.Nil(t, err)
+	require.Equal(t,
+		[]Token{
+			Number{Value: "1"},
+			Operator{Value: "+"},
+			Identifier{Value: "a"},
+		},
+		tokens)
+
+	tokens, err = Lex("(a)")
+	require.Nil(t, err)
+	require.Equal(t,
+		[]Token{
+			LeftParentheses{},
+			Identifier{Value: "a"},
+			RightParentheses{},
+		},
+		tokens)
+
+	tokens, err = Lex("(1)a")
+	require.EqualError(t, err, "Lexing Error: character 'a' is not expected after )")
+	require.Equal(t,
+		[]Token{
+			LeftParentheses{},
+			Number{Value: "1"},
+			RightParentheses{},
+		},
+		tokens)
+
+	tokens, err = Lex("a")
+	require.Nil(t, err)
+	require.Equal(t,
+		[]Token{
+			Identifier{Value: "a"},
+		},
+		tokens)
+
+	tokens, err = Lex("babcccccc == 2")
+	require.Nil(t, err)
+	require.Equal(t,
+		[]Token{
+			Identifier{Value: "babcccccc"},
+			EqualSign{},
+			EqualSign{},
+			Number{Value: "2"},
+		},
+		tokens)
 }

--- a/projects/galculator/internel/lexer/state_transition.go
+++ b/projects/galculator/internel/lexer/state_transition.go
@@ -1,0 +1,7 @@
+package lexer
+
+import "bytes"
+
+func validIdentifierRune(r rune) bool {
+	return bytes.ContainsRune([]byte("abc"), r)
+}

--- a/projects/galculator/internel/lexer/token.go
+++ b/projects/galculator/internel/lexer/token.go
@@ -49,6 +49,20 @@ func (p RightParentheses) Type() string {
 	return "Right Parentheses"
 }
 
+// Identifier is a name.
+// For example, a = 1, the identifier will be a
+type Identifier struct {
+	Value string
+}
+
+func (i Identifier) Literal() string {
+	return i.Value
+}
+
+func (i Identifier) Type() string {
+	return "Identifier"
+}
+
 var (
 	Add = Operator{
 		Value: "+",
@@ -63,3 +77,13 @@ var (
 		Value: "/",
 	}
 )
+
+type EqualSign struct{}
+
+func (i EqualSign) Literal() string {
+	return "="
+}
+
+func (i EqualSign) Type() string {
+	return "Equal Sign"
+}

--- a/projects/galculator/internel/repl/repl.go
+++ b/projects/galculator/internel/repl/repl.go
@@ -12,6 +12,7 @@ import (
 // It's an interactive console so to speak.
 func REPL() error {
 	buf := bufio.NewReader(os.Stdin)
+	vm := make(map[string]int64)
 	for {
 		fmt.Print("> ")
 		sentence, err := buf.ReadBytes('\n')
@@ -27,6 +28,6 @@ func REPL() error {
 		if len(sentence) <= trim {
 			continue
 		}
-		fmt.Println(compute.Compute(string(sentence[:len(sentence)-trim])))
+		fmt.Println(compute.Compute(string(sentence[:len(sentence)-trim]), vm))
 	}
 }


### PR DESCRIPTION
目前还有这么一个奇怪的 Bug
```
> a = 1
1
> a=1
Parsing Error: An identifier must be followed by 1 of the 4: = expression, operator expression, ), EOF. But got lexer.Number:{1}
> a =1
1
> a= 1
Parsing Error: An identifier must be followed by 1 of the 4: = expression, operator expression, ), EOF. But got lexer.Number:{1}
```